### PR TITLE
Running tests in ci

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,7 +2,7 @@ name: Haskell CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master running-tests-in-ci ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,9 +2,9 @@ name: Haskell CI
 
 on:
   push:
-    branches: [ master running-tests-in-ci ]
+    branches: [ master, running-tests-in-ci ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, running  ]
 
 jobs:
   build:

--- a/src/Util/Util.hs
+++ b/src/Util/Util.hs
@@ -168,6 +168,8 @@ runTest test duration = do
     let dirName  = parent   test
     let testName = filename test
 
+    print =<< getCurrentDirectory
+
     print "runTest"
     print dirName
     print testName

--- a/test-cases/regressions/funids.sh
+++ b/test-cases/regressions/funids.sh
@@ -1,2 +1,2 @@
-#!/run/current-system/sw/bin/bash
+#!/bin/bash
 ghc FunIds.hs

--- a/test-cases/regressions/interesting.sh
+++ b/test-cases/regressions/interesting.sh
@@ -1,2 +1,2 @@
-#!/run/current-system/sw/bin/bash
+#!/bin/bash
 exit 0


### PR DESCRIPTION
Interestingness tests for the integration / regression tests of reduction passes were complaining that they couldn't find bash because it was using the nixos path which does not work in ubuntu.